### PR TITLE
Define and implement a new power consumption model

### DIFF
--- a/ShipyardMod/ItemClasses/ShipyardItem.cs
+++ b/ShipyardMod/ItemClasses/ShipyardItem.cs
@@ -8,6 +8,7 @@ using VRage;
 using VRage.Game.ModAPI;
 using VRage.ModAPI;
 using VRageMath;
+using System;
 
 namespace ShipyardMod.ItemClasses
 {
@@ -139,6 +140,67 @@ namespace ShipyardMod.ItemClasses
             Communication.SendButtonAction(YardEntity.EntityId, index);
         }
 
+        /*
+         * Worst case power usage would be a grid of 24+ blocks immediately
+         * inside one corner of our yard.  All (up to) 24 of our lasers will be
+         * required to weld/grind this grid, but the lasers from the opposite
+         * corner would be the longest, effectively equal to the diagonal
+         * length of our yard.
+         * 
+         * (each corner block)
+         *     base power = 5
+         *     (each laser)
+         *         base power = 30
+         *         additional power = 300 * Max(WeldMultiplier, GrindMultiplier) * (YardDiagonal / 200000)
+         * 
+         * For balance, we scale power usage so that when YardDiag^2 == 200,000
+         * (the same distance that our component effeciency bottoms out: ~450m),
+         * each //LASER// at 1x multiplier consumes the full output of a Large
+         * Reactor (300 MW).
+         * 
+         * To put that in perspective, a cubical shipyard with a ~450m diagonal
+         * would be ~250m on each edge, or about 100 large blocks. But keep in
+         * mind: even with a shipyard this big, as long as the target grid is
+         * centered within the volume of the shipyard, laserLength would only
+         * be 225m, not the full 450m.  And at 225m, each laser consumes only 
+         * 75 MW: 25% of the max.  So with a shipyard of this size, centering
+         * your target grid gets more and more important.
+         * 
+         * Unlike component efficiency, however, which bottoms out to a fixed
+         * "minimum" efficiency past 450m, power requirements for lasers longer
+         * than this will continue to increase exponentially.
+         * 
+         * This really only needs to be called whenever yard settings are changed
+         * (since BeamCount and multipliers affect this calculation), or when the
+         * yard changes state (weld/grind/disable)
+         */
+        public void UpdateMaxPowerUse()
+        {
+            float multiplier;
+            var corners = new Vector3D[8];
+            ShipyardBox.GetCorners(corners, 0);
+
+            if (YardType == ShipyardType.Weld)
+            {
+                multiplier = Settings.WeldMultiplier;
+            }
+            else if (YardType == ShipyardType.Grind)
+            {
+                multiplier = Settings.GrindMultiplier;
+            }
+            else
+            {
+                // Yard is neither actively welding or grinding right now, so just show worst case
+                multiplier = Math.Max(Settings.WeldMultiplier, Settings.GrindMultiplier);
+            }
+
+            float maxpower = 5 + Settings.BeamCount * (30 + 300 * multiplier * (float)Vector3D.DistanceSquared(corners[0], corners[6]) / 200000);
+
+            foreach (IMyCubeBlock tool in Tools)
+            {
+                ((IMyCollector)tool).GameLogic.GetAs<ShipyardCorner>().SetMaxPower(maxpower);
+            }
+        }
         public void UpdatePowerUse()
         {
             if (YardType == ShipyardType.Disabled || YardType == ShipyardType.Invalid)
@@ -154,23 +216,35 @@ namespace ShipyardMod.ItemClasses
             }
             else
             {
+                float multiplier;
+                if (YardType == ShipyardType.Weld)
+                {
+                    multiplier = Settings.WeldMultiplier;
+                }
+                else
+                {
+                    multiplier = Settings.GrindMultiplier;
+                }
+
                 Utilities.Invoke(() =>
                                  {
                                      foreach (IMyCubeBlock tool in Tools)
                                      {
                                          float power = 5;
+                                         Logging.Instance.WriteDebug(String.Format("Tool[{0}] Base power usage [{1:F1} MW]", tool.DisplayNameText, power));
+                                         int i = 0;
                                          foreach (BlockTarget blockTarget in BlocksToProcess[tool.EntityId])
                                          {
                                              if (blockTarget == null)
                                                  continue;
-                                             //the value 8 here is a coincidence, not to do with the number of corners on a box
-                                             float powerReq = 30 + (float)blockTarget.ToolDist[tool.EntityId] / 8;
-                                             if (YardType == ShipyardType.Weld)
-                                                 power += powerReq * Settings.WeldMultiplier;
-                                             else if (YardType == ShipyardType.Grind)
-                                                 power += powerReq * Settings.GrindMultiplier;
+
+                                             float laserPower = 30 + 300 * multiplier * (float)blockTarget.ToolDist[tool.EntityId] / 200000;
+                                             Logging.Instance.WriteDebug(String.Format("Tool[{0}] laser[{1}] distance[{2:F1}m] multiplier[{3:F1}x] additional power req [{4:F1} MW]", tool.DisplayNameText, i, Math.Sqrt(blockTarget.ToolDist[tool.EntityId]), multiplier, laserPower));
+                                             power += laserPower;
+                                             i++;
                                          }
-                                         
+
+                                         Logging.Instance.WriteDebug(String.Format("Tool[{0}] Total computed power [{1:F1} MW]", tool.DisplayNameText, power));
                                          tool.GameLogic.GetAs<ShipyardCorner>().SetPowerUse(power);
                                          Communication.SendToolPower(tool.EntityId, power);
                                      }

--- a/ShipyardMod/ProcessHandlers/ProcessShipyardDetection.cs
+++ b/ShipyardMod/ProcessHandlers/ProcessShipyardDetection.cs
@@ -101,7 +101,7 @@ namespace ShipyardMod.ProcessHandlers
                 var gridBlocks = new List<IMySlimBlock>();
                 grid.GetBlocks(gridBlocks);
 
-                foreach (IMySlimBlock slimBlock in gridBlocks.ToArray())
+                foreach (IMySlimBlock slimBlock in gridBlocks)
                 {
                     var collector = slimBlock.FatBlock as IMyCollector;
                     if (collector == null)

--- a/ShipyardMod/Utility/Communication.cs
+++ b/ShipyardMod/Utility/Communication.cs
@@ -471,21 +471,15 @@ namespace ShipyardMod.Utility
                 buttons.SetEmissiveParts("Emissive3", blockDef.ButtonColors[3 % blockDef.ButtonColors.Length], 1);
                 buttons.SetEmissiveParts("Emissive4", blockDef.ButtonColors[4 % blockDef.ButtonColors.Length], 1);
             }
-            yardItem.Settings = ShipyardSettings.Instance.GetYardSettings(yardItem.EntityId);
-            ProcessLocalYards.LocalYards.Add(yardItem);
-            var corners = new Vector3D[8];
-            yardItem.ShipyardBox.GetCorners(corners, 0);
-            //check ShipyardItem.UpdatePowerUse for details on this value
-            float maxpower = 5 + (float)Vector3D.DistanceSquared(corners[0], corners[6]) / 8;
-            maxpower += 90;
 
             foreach (IMyCubeBlock tool in yardItem.Tools)
             {
                 var corner = ((IMyCollector)tool).GameLogic.GetAs<ShipyardCorner>();
-                corner.SetMaxPower(maxpower);
                 corner.Shipyard = yardItem;
                 //tool.SetEmissiveParts("Emissive1", Color.Yellow, 0f);
             }
+
+            yardItem.UpdateMaxPowerUse();
         }
 
         private static void HandleShipyardState(byte[] data)
@@ -538,6 +532,8 @@ namespace ShipyardMod.Utility
                     //default:
                     //    throw new ArgumentOutOfRangeException();
                 }
+
+                yard.UpdateMaxPowerUse();
                 
             }
         }
@@ -629,6 +625,7 @@ namespace ShipyardMod.Utility
                     continue;
 
                 yard.Settings = settings;
+                yard.UpdateMaxPowerUse();  // BeamCount and Multiplier affect our maxpower calculation
                 ShipyardSettings.Instance.SetYardSettings(yard.EntityId, settings);
                 found = true;
                 break;
@@ -640,6 +637,7 @@ namespace ShipyardMod.Utility
                     continue;
 
                 yard.Settings = settings;
+                yard.UpdateMaxPowerUse();  // BeamCount and Multiplier affect our maxpower calculation
                 ShipyardSettings.Instance.SetYardSettings(yard.EntityId, settings);
                 
                 foreach (IMyCubeBlock tool in yard.Tools)


### PR DESCRIPTION
Define and implement a new power consumption model.  Each laser starts at 30 MW and increases exponentially with distance so that at 450m (and a grind/weld multiplier of 1x) it consumes 300 MW (the output of a Large Reactor).  This is roughly the same exponential curve observed by our welder/grinder component efficiency, except that instead of plateauing at distances > 450m, power usage continues to increase indefinitely.  See full analysis in ShipyardItem.cs:144